### PR TITLE
Move and Rename media

### DIFF
--- a/src/nefarious/api/mixins.py
+++ b/src/nefarious/api/mixins.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 
 from nefarious.models import NefariousSettings, TorrentBlacklist, WatchMediaBase
 from nefarious.transmission import get_transmission_client
+from nefarious.utils import destroy_transmission_result
 
 
 class UserReferenceViewSetMixin:
@@ -62,10 +63,5 @@ class DestroyTransmissionResultMixin:
 
     def perform_destroy(self, instance: WatchMediaBase):
         # delete transmission result, including data, if it still exists
-        nefarious_settings = NefariousSettings.get()
-        try:
-            transmission_client = get_transmission_client(nefarious_settings)
-            transmission_client.remove_torrent([instance.transmission_torrent_hash], delete_data=True)
-        except:
-            logging.warning('could not connect to transmission to delete the torrent')
+        destroy_transmission_result(instance)
         super().perform_destroy(instance)

--- a/src/nefarious/tasks.py
+++ b/src/nefarious/tasks.py
@@ -163,7 +163,7 @@ def completed_media_task():
                 ).lstrip('/')
 
                 # get the new name and path for the data
-                new_name, new_path = get_media_new_name_and_path(media, torrent.name)
+                new_name, new_path = get_media_new_name_and_path(media, torrent.name, len(torrent.files()) == 1)
 
                 # move the data
                 transmission_session = transmission_client.session_stats()

--- a/src/nefarious/tests/test_rename.py
+++ b/src/nefarious/tests/test_rename.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from nefarious.utils import get_media_new_name_and_path
 
 
-class RenameTorrentPaths(TestCase):
+class RenameTorrentsAndPaths(TestCase):
     tests = []
 
     def setUp(self):
@@ -25,7 +25,7 @@ class RenameTorrentPaths(TestCase):
             (episode, "Rick.and.Morty.S01E14.720p.AMZN.WEBRip.DDP5.1.x264-NTb[rartv].mkv", "S01E14.mkv", "Rick and Morty/Season 01", True),
         ]
 
-    def test_tv(self):
+    def test_rename(self):
         for test_media, test_torrent, test_name, test_path, is_single_file in self.tests:
             name, path = get_media_new_name_and_path(test_media, test_torrent, is_single_file)
             self.assertEquals(test_name, name)

--- a/src/nefarious/tests/test_rename.py
+++ b/src/nefarious/tests/test_rename.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from nefarious.models import WatchMovie, WatchTVSeason, WatchTVShow, WatchTVEpisode
+from django.test import TestCase
+from nefarious.utils import get_media_new_name_and_path
+
+
+class RenameTorrentPaths(TestCase):
+    tests = []
+
+    def setUp(self):
+        movie = WatchMovie(name='Rambo', release_date=datetime(1982, 1, 1))
+        show = WatchTVShow(name='Rick and Morty')
+        season = WatchTVSeason(watch_tv_show=show, season_number=1)
+        episode = WatchTVEpisode(watch_tv_show=show, season_number=1, episode_number=14)
+        self.tests = [
+            # movie folder
+            (movie, "Rambo.1982.1080p.BluRay", "Rambo (1982)", "Rambo (1982)", False),
+            # movie single file
+            (movie, "Rambo.1982.1080p.BluRay.mkv", "Rambo (1982).mkv", "Rambo (1982)", True),
+            # full season
+            (season, "Rick.and.Morty.S01.720p.AMZN.WEBRip.DDP5.1.x264-NTb[rartv]", "Season 01", "Rick and Morty", False),
+            # single episode folder
+            (episode, "Rick.and.Morty.S01E14.720p.AMZN.WEBRip.DDP5.1.x264-NTb[rartv]", "S01E14", "Rick and Morty/Season 01", False),
+            # single episode single file
+            (episode, "Rick.and.Morty.S01E14.720p.AMZN.WEBRip.DDP5.1.x264-NTb[rartv].mkv", "S01E14.mkv", "Rick and Morty/Season 01", True),
+        ]
+
+    def test_tv(self):
+        for test_media, test_torrent, test_name, test_path, is_single_file in self.tests:
+            name, path = get_media_new_name_and_path(test_media, test_torrent, is_single_file)
+            self.assertEquals(test_name, name)
+            self.assertEquals(test_path, path)

--- a/src/nefarious/utils.py
+++ b/src/nefarious/utils.py
@@ -6,7 +6,7 @@ from typing import List
 import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 from transmissionrpc import TransmissionError
-from nefarious.models import NefariousSettings, WatchMovie, WatchTVSeason, WatchTVEpisode
+from nefarious.models import NefariousSettings, WatchMovie, WatchTVSeason, WatchTVEpisode, WatchMediaBase
 from nefarious.tmdb import get_tmdb_client
 from nefarious.transmission import get_transmission_client
 
@@ -180,3 +180,14 @@ def get_media_new_name_and_path(watch_media, torrent_name: str, is_single_file=F
             name += extension
 
     return name, dir_name
+
+
+def destroy_transmission_result(instance: WatchMediaBase):
+    # delete transmission result, including data, if it still exists
+    nefarious_settings = NefariousSettings.get()
+    try:
+        transmission_client = get_transmission_client(nefarious_settings)
+        transmission_client.remove_torrent([instance.transmission_torrent_hash], delete_data=True, timeout=10)
+    except Exception as e:
+        logging.warning(str(e))
+        logging.warning('could not destroy torrent in transmission')

--- a/src/nefarious/utils.py
+++ b/src/nefarious/utils.py
@@ -1,11 +1,12 @@
 import logging
+import os
 import regex
 import requests
 from typing import List
 import xml.etree.ElementTree as ET
 from urllib.parse import urlparse
 from transmissionrpc import TransmissionError
-from nefarious.models import NefariousSettings, WatchMovie
+from nefarious.models import NefariousSettings, WatchMovie, WatchTVSeason, WatchTVEpisode
 from nefarious.tmdb import get_tmdb_client
 from nefarious.transmission import get_transmission_client
 
@@ -131,15 +132,51 @@ def results_with_valid_urls(results: list, nefarious_settings: NefariousSettings
     return populated_results
 
 
-def get_renamed_torrent(torrent, watch_media):
-    new_name = str(watch_media)
-    # append year for Movies, i.e "Toy Story 4 (2019)"
-    if isinstance(watch_media, WatchMovie) and watch_media.release_date:
-        new_name += ' ({})'.format(watch_media.release_date.year)
+def get_media_new_name_and_path(watch_media, torrent_name: str, is_single_file=False) -> tuple:
+    """
+    Returns a tuple of the media name and the path to where it should be moved.
+    Movie Single File:
+        Input: "Rambo [scene-stuff].mkv"
+        Output: ("Rambo (1982).mkv", "Rambo (1982)")
+    Movie Folder:
+        Input: "Rambo [scene-stuff]"
+        Output: ("Rambo (1982)", "Rambo (1982)/")
+    TV Single Episode Folder:
+        Input: "Rick and Morty - S03E14 [scene-stuff]"
+        Output: ("S03E14", "Rick and Morty/Season 3/")
+    TV Single Episode File:
+        Input: "Rick and Morty - S03E14 [scene-stuff].mkv"
+        Output ("S03E14.mkv", "Rick and Morty/Season 3/")
+    TV Full Full Season Folder:
+        Input: "Rick and Morty - Season 3 [scene-stuff]"
+        Output: ("Season 3", "Rick and Morty/")
+    """
+
+    # movie
+    if isinstance(watch_media, WatchMovie):
+        name = '{} ({})'.format(watch_media, watch_media.release_date.year)
+        dir_name = name
+
+    # tv
+    else:
+        # full season
+        if isinstance(watch_media, WatchTVSeason):
+            season = watch_media  # type WatchTVSeason
+            name = 'Season {:02d}'.format(season.season_number)
+            dir_name = str(season.watch_tv_show)
+        # single episode
+        elif isinstance(watch_media, WatchTVEpisode):
+            episode = watch_media  # type WatchTVEpisode
+            name = 'S{:02d}E{:02d}'.format(episode.season_number, episode.episode_number)
+            dir_name = os.path.join(str(episode.watch_tv_show), 'Season {:02d}'.format(episode.season_number))
+        else:
+            raise Exception('unknown media')
+
     # maintain extension if torrent is a single file vs a directory
-    if len(torrent.files()) == 1:
-        extension_match = regex.search(r'(\.\w+)$', torrent.name)
+    if is_single_file:
+        extension_match = regex.search(r'(\.\w+)$', torrent_name)
         if extension_match:
             extension = extension_match.group()
-            new_name += extension
-    return new_name
+            name += extension
+
+    return name, dir_name


### PR DESCRIPTION
This aims to address issue #19.  It now structures TV into folders in a more organized way.

Series -> Season -> Show.

For example:

### Single episode (folder):
- Rick.and.Morty.S01E14.720p[rartv]

would save to
- Rick and Morty/Season 01/S01E14/

*It's kind of weird to save a sub-folder beneath the episode, but I didn't have a great of way handling this. There may include separate subtitles that need to stay in it's own folder?*

### Single episode (single file)
- Rick.and.Morty.S01E14.720p[rartv].mkv

would save to
- Rick and Morty/Season 01/S01E14.mkv

### Full Season
- Rick.and.Morty.S01.720p.AMZN.WEBRip.DDP5.1.x264-NTb[rartv]

would save to 
- Rick and Morty/Season 01

**Additionally, I fixed an unrelated issue where torrents weren't being deleted when a Season was requested to stop watching**.