### PR TITLE
Handle possessive apostrophes

### DIFF
--- a/src/nefarious/utils.py
+++ b/src/nefarious/utils.py
@@ -132,7 +132,7 @@ def results_with_valid_urls(results: list, nefarious_settings: NefariousSettings
             continue
 
         # add torrent to valid search results
-        logger_background.info('Valid Match: {} with {} Seeders'.format(result['Title'], result['Seeders']))
+        logger_background.info('Valid Match: "{}" with {} Seeders'.format(result['Title'], result['Seeders']))
         populated_results.append(result)
 
     return populated_results


### PR DESCRIPTION
Handle possessive apostrophes: search "Handmaid's Tale" and then fallback to "Handmaids Tale" since indexers/rippers handle these different.