### PR TITLE
need libpq-dev to build, but need libpq5 to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.8-venv \
     python3.8-dev \
     python3.8-gdbm \
+    libpq5 \
     libpq-dev \
     virtualenv \
     gnupg \


### PR DESCRIPTION
I missed that libpq5 (not the dev headers) need to be installed, or psycopg2 throws an error on connect.