### PR TITLE
Update transmission-settings.json

### DIFF
--- a/transmission-settings.json
+++ b/transmission-settings.json
@@ -4,4 +4,7 @@
     "incomplete-dir-enabled": "true",
     "rpc-whitelist": "*",
     "rpc-host-whitelist-enabled": "false"
+    "rpc-password": "admin",
+    "rpc-username": "admin",
+    "rpc-authentication-required": "true"
 }


### PR DESCRIPTION
I think forcing a default password is a good idea specially for folks who run Nefarious on a cloud hosted server. This would need to be reflected in the readme, happy to submit a pull for that as well. This is being discussed in #159 