### PR TITLE
Add IPv6 sysctls flag and documentation

### DIFF
--- a/docker-compose.transmission-vpn.yml
+++ b/docker-compose.transmission-vpn.yml
@@ -43,6 +43,8 @@ services:
     volumes:
       - ${HOST_DOWNLOAD_PATH:-/tmp}:/data
       - /etc/localtime:/etc/localtime:ro
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=${VPN_IPV6_DISABLED:-1} # 0=enabled, 1=disabled
     environment:
       - OPENVPN_PROVIDER=${OPENVPN_PROVIDER}
       - OPENVPN_USERNAME=${OPENVPN_USERNAME}

--- a/docs/VPN.md
+++ b/docs/VPN.md
@@ -3,7 +3,7 @@
 To secure Transmission and Jackett traffic with a VPN you must use the separate `docker-compose.transmission-vpn.yml` file and populate the `.env` with your
 VPN provider's details.
 
-The documentation for supported providers and additional configuration can be found at: [docker-transmission-openvpn](https://haugene.github.io/docker-transmission-openvpn/).
+The documentation for supported providers and additional configuration can be found at: [docker-transmission-openvpn](https://haugene.github.io/docker-transmission-openvpn/). For [some VPNs](https://haugene.github.io/docker-transmission-openvpn/provider-specific) IPv6 must be **enabled**. To enable it, set `VPN_IPV6_DISABLED=0` in your `.env` file.
 
 All docker-compose commands must specify the `docker-compose.transmission-vpn.yml` file explicitly.
 
@@ -12,3 +12,7 @@ For example, to bring up all the services, you'd run:
     docker-compose -f docker-compose.transmission-vpn.yml up -d
 
 **NOTE**: You must also define the *jackett* host described in [Part 2](../README.md#part-2) as `transmission` vs `jackett` since the transmission service is also the VPN.
+
+## Port Forwarding
+
+If you want to use Transmission in Active Mode your VPN provider must support [Port Forwarding](https://haugene.github.io/docker-transmission-openvpn/building-blocks/#starting_transmission). For some VPN providers it will be enabled automatically. For others you manually need to configure the Peer Port using the transmission user interface. 

--- a/env.template
+++ b/env.template
@@ -25,3 +25,6 @@ OPENVPN_USERNAME=
 OPENVPN_PASSWORD=
 OPENVPN_CONFIG=
 LOCAL_NETWORK=192.168.1.0/24
+# leave blank if your vpn doesn't require IPv6
+# 0=enabled, 1=disabled
+VPN_IPV6_DISABLED=


### PR DESCRIPTION
Related to our discussion in #158:
- Add optional sysctls flag to VPN docker compose file to support VPNs with IPv6 requirement
- Document how to use Peer Ports with VPN & Transmission

It's suboptimal that this `disable` flag is a bit confusing but I don't see a better way, as docker-compose removed the "enable_ipv6" flag and negation isn't possible in `YAML`

PS: Seems like you need to remove the travis check requirement as this is using Github Actions now?