### PR TITLE
Media results are proper href's with an RT middleware component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         id: tag_name
         shell: bash
         run: |
-          # get and sanitize branch name
+          # get and sanitize the branch name
           branch=${GITHUB_REF#refs/heads/}
           branch=${branch//\//-}
           # derive the docker image tag name from the git branch name

--- a/src/frontend/src/app/app.module.ts
+++ b/src/frontend/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { WantedComponent } from './wanted/wanted.component';
 import { RottenTomatoesComponent } from './rotten-tomatoes/rotten-tomatoes.component';
 import { TmdbComponent } from './tmdb/tmdb.component';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { RottenTomatoesRedirectComponent } from './rotten-tomatoes-redirect/rotten-tomatoes-redirect.component';
 
 const appRoutes: Routes = [
   { path: '', redirectTo: 'search/auto', pathMatch: 'full' },  // redirects
@@ -58,6 +59,7 @@ const appRoutes: Routes = [
       { path: 'rt', component: RottenTomatoesComponent },
     ],
   },
+  { path: 'rt-redirect/:mediaType/:title', component: RottenTomatoesRedirectComponent },
   { path: 'page-not-found', component: PageNotFoundComponent },
   { path: '**', component: PageNotFoundComponent }
 ];
@@ -92,6 +94,7 @@ export function init(apiService: ApiService) {
     WantedComponent,
     RottenTomatoesComponent,
     TmdbComponent,
+    RottenTomatoesRedirectComponent,
   ],
   imports: [
     RouterModule.forRoot(

--- a/src/frontend/src/app/media-results/media-results.component.html
+++ b/src/frontend/src/app/media-results/media-results.component.html
@@ -8,8 +8,7 @@
     </div>
     <div class="row">
       <ngx-loading [show]="isLoading"></ngx-loading>
-      <!-- TODO - clicking result should be an href so you can open a new tab (use href/routerLink that does a redirect once it handles rotten tomato results) -->
-      <div class="col-12 col-sm-6 col-md-4 col-lg-3 result" *ngFor="let result of results | mediaFilter: search" (click)="navigateToMedia(result)">
+      <a [routerLink]="getMediaURL(result)" class="col-12 col-sm-6 col-md-4 col-lg-3 result text-white" *ngFor="let result of results | mediaFilter: search">
         <div class="card" [ngClass]="{'border border-success rounded': isWatchingResult(result)}">
           <div class="result-watching">
             <div class="d-flex justify-content-end">
@@ -28,16 +27,16 @@
             </ng-container>
             <div class="d-flex justify-content-end rotten-tomato" *ngIf="isRottenTomatoResult(result)">
               <div>
-                <img *ngIf="result.tomato_icon === 'certified_fresh'" src="/static/assets/rt-fresh.png">
-                <img *ngIf="result.tomato_icon === 'fresh'" src="/static/assets/rt-regular.png">
-                <img *ngIf="result.tomato_icon === 'rotten'" src="/static/assets/rt-splat.png">
+                <img *ngIf="result.tomato_icon === 'certified_fresh'" src="/static/assets/rt-fresh.png" alt="">
+                <img *ngIf="result.tomato_icon === 'fresh'" src="/static/assets/rt-regular.png" alt="">
+                <img *ngIf="result.tomato_icon === 'rotten'" src="/static/assets/rt-splat.png" alt="">
                 <span class="score ml-1">{{ result.tomato_score }}</span>
               </div>
             </div>
-            <p class="card-text"[innerHTML]="result.overview"></p>
+            <p class="card-text" [innerHTML]="result.overview"></p>
           </div>
         </div>
-      </div>
+      </a>
     </div>
   </div>
 </div>

--- a/src/frontend/src/app/media-results/media-results.component.ts
+++ b/src/frontend/src/app/media-results/media-results.component.ts
@@ -1,5 +1,3 @@
-import { ToastrService } from 'ngx-toastr';
-import { Router } from '@angular/router';
 import { Component, OnInit, Input } from '@angular/core';
 import { ApiService } from '../api.service';
 
@@ -16,8 +14,6 @@ export class MediaResultsComponent implements OnInit {
 
   constructor(
     private apiService: ApiService,
-    private router: Router,
-    private toastr: ToastrService,
   ) {
   }
 
@@ -49,36 +45,12 @@ export class MediaResultsComponent implements OnInit {
     }
   }
 
-  public navigateToMedia(result: any) {
-    // rotten tomato results must be searched against tmdb and then routed
+  public getMediaURL(result: any) {
+    // rotten tomato results must be searched against tmdb first, so we'll redirect to its own component for that
     if (this.isRottenTomatoResult(result)) {
-      this.isLoading = true;
-      this.apiService.searchMedia(result.title, this.mediaType).subscribe(
-        (data) => {
-          if (data.results && data.results.length > 0) {
-            // try and find an exact match, otherwise fallback to first result
-            let match = data.results.find((movie) => {
-              return movie.title === result.title;
-            });
-            if (!match) {
-              match = data.results[0];
-            }
-            this.router.navigate(['/media', this.mediaType, match.id]);
-          } else {
-            this.toastr.error('No results found for title in TMDB');
-          }
-        },
-        (error) => {
-          console.error(error);
-          this.toastr.error('An unknown error occurred');
-          this.isLoading = false;
-        },
-        () => {
-          this.isLoading = false;
-        },
-      );
+      return ['/rt-redirect', this.mediaType, result.title];
     } else {
-      this.router.navigate(['/media', this.mediaType, result.id]);
+      return ['/media', this.mediaType, result.id];
     }
   }
 

--- a/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.html
+++ b/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.html
@@ -1,0 +1,12 @@
+<div class="alert alert-info" *ngIf="isLoading">
+  <ngx-loading [show]="isLoading"></ngx-loading>
+  Searching Rotten Tomatoes for <strong>{{ title }}...</strong>
+</div>
+
+<!-- many results found so let the user choose -->
+<div *ngIf="results">
+  <div class="alert alert-warning">
+    Results for title <strong>{{ title }}</strong> from <strong>Rotten Tomatoes</strong> didn't perfectly match with <strong>TMDB</strong> so please choose a correct match:
+  </div>
+  <app-media-results [mediaType]="mediaType" [results]="results"></app-media-results>
+</div>

--- a/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.spec.ts
+++ b/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RottenTomatoesRedirectComponent } from './rotten-tomatoes-redirect.component';
+
+describe('RottenTomatoesRedirectComponent', () => {
+  let component: RottenTomatoesRedirectComponent;
+  let fixture: ComponentFixture<RottenTomatoesRedirectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RottenTomatoesRedirectComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RottenTomatoesRedirectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.ts
+++ b/src/frontend/src/app/rotten-tomatoes-redirect/rotten-tomatoes-redirect.component.ts
@@ -1,0 +1,56 @@
+import { ActivatedRoute, Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../api.service';
+import { ToastrService } from 'ngx-toastr';
+
+@Component({
+  selector: 'app-rotten-tomatoes-redirect',
+  templateUrl: './rotten-tomatoes-redirect.component.html',
+  styleUrls: ['./rotten-tomatoes-redirect.component.css']
+})
+export class RottenTomatoesRedirectComponent implements OnInit {
+  public isLoading = true;
+  public title: string;
+  public mediaType: string;
+  public results: any[];
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+    private apiService: ApiService,
+    private toastr: ToastrService,
+  ) { }
+
+  ngOnInit(): void {
+    this.title = this.route.snapshot.params['title'];
+    this.mediaType = this.route.snapshot.params['mediaType'];
+
+    this.isLoading = true;
+    this.apiService.searchMedia(this.title, this.mediaType).subscribe(
+      (data) => {
+        if (data.results && data.results.length > 0) {
+          // try and find an exact match, otherwise fallback to first result
+          let match = data.results.find((movie) => {
+            return movie.title === this.title;
+          });
+          // perfect match so redirect to media
+          if (match) {
+            this.router.navigate(['/media', this.mediaType, match.id], { replaceUrl: true });  // no history so we can go "backwards"
+          } else { // display results so user can choose
+            this.results = data.results;
+          }
+        } else {
+          this.toastr.error('No results found for title in TMDB');
+        }
+      },
+      (error) => {
+        console.error(error);
+        this.toastr.error('An unknown error occurred');
+        this.isLoading = false;
+      },
+      () => {
+        this.isLoading = false;
+      },
+    );
+  }
+}


### PR DESCRIPTION
Previously, media results weren't true href's and therefore couldn't open them in new tabs which was annoying.

This is fixed and was accomplished by using a rotten-tomatoes redirect component and let user choose when matches are ambiguous.

![image](https://user-images.githubusercontent.com/45122868/217375273-e4ce9ecd-00f2-4542-83d2-cd8c474a8c0a.png)
