### PR TITLE
Send optional notifications for bad/fake video attempts

### DIFF
--- a/src/nefarious/tasks.py
+++ b/src/nefarious/tasks.py
@@ -173,7 +173,8 @@ def completed_media_task():
                             logger_background.info("[VIDEO_DETECTION] '{}' has valid video files".format(media))
                         else:
                             blacklist_media_and_retry(media)
-                            logger_background.error("[VIDEO_DETECTION] blacklisting '{}' because no valid video was found: {}".format(media, staging_path))
+                            logger_background.error("[VIDEO_DETECTION] blacklisting '{}' because no valid video was found in {}".format(media, staging_path))
+                            notification.send_message('blacklisted movie {} because no valid videos found ({}: {})'.format(media, torrent.name, media.transmission_torrent_hash))
                             continue
                     except Exception as e:
                         logger_background.exception(e)


### PR DESCRIPTION
When the optional video detection setting is enabled, and a movie was detected as "bad"/"fake", it'll be denied and a message will be sent via the user's notification settings.