### PR TITLE
pin Apprise links to current version (0.9.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features:
 - [x] Includes movie trailers
 - [x] Automatically renames media
 - [x] Supports multiple languages (TMDB supports internationalized Titles, Descriptions and Poster artwork)
-- [x] Notifications - supports all major notification services (via [Apprise](https://github.com/caronc/apprise))
+- [x] Notifications - supports all major notification services (via [Apprise](https://github.com/caronc/apprise/tree/v0.9.3))
 - [x] Imports existing libraries
 - [x] VPN integration (optional)
 - [x] Auto download subtitles via [opensubtitles](https://www.opensubtitles.com/) [api](https://opensubtitles.stoplight.io/)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -73,8 +73,8 @@ If you want to see the logs you can run:
 ## Notifications
 
 nefarious can send notifications (e.g. push notifications, email, sms) when media is downloaded.   
-See [Apprise](https://github.com/caronc/apprise) for documentation on how to construct the *Notification Url* for
-the [available notification services](https://github.com/caronc/apprise#popular-notification-services).
+See [Apprise](https://github.com/caronc/apprise/tree/v0.9.3) for documentation on how to construct the *Notification Url* for
+the [available notification services](https://github.com/caronc/apprise/tree/v0.9.3#popular-notification-services).
 
 Enter the *Notification Url* on the settings page.  You can test it from there to make sure it works as expected.
 

--- a/src/frontend/src/app/settings/settings.component.html
+++ b/src/frontend/src/app/settings/settings.component.html
@@ -172,7 +172,7 @@
         <div class="card-header">Notifications</div>
         <div class="card-body">
           <p>Defining a <i>Notification URL</i> allows you to get notified when downloads are complete.</p>
-          <p>nefarious uses <a target="_blank" href="https://github.com/caronc/apprise">Apprise</a> for notifications which supports <a target="_blank" href="https://github.com/caronc/apprise#productivity-based-notifications">most major notification services.</a></p>
+          <p>nefarious uses <a target="_blank" href="https://github.com/caronc/apprise/tree/v0.9.3">Apprise</a> for notifications which supports <a target="_blank" href="https://github.com/caronc/apprise#productivity-based-notifications">most major notification services.</a></p>
           <div class="my-2">
             <label>Notification URL</label>
             <input type="text" class="form-control" placeholder="slack://TokenA/TokenB/TokenC/" formControlName="apprise_notification_url">

--- a/src/nefarious/models.py
+++ b/src/nefarious/models.py
@@ -59,7 +59,7 @@ class NefariousSettings(models.Model):
     # expects keyword/boolean pairs like {"x265": false, "265": false}
     keyword_search_filters = JSONField(blank=True, null=True)  # type: dict
 
-    # apprise notifications - https://github.com/caronc/apprise
+    # apprise notifications - https://github.com/caronc/apprise/tree/v0.9.3
     apprise_notification_url = models.CharField(max_length=1000, blank=True)
 
     # category of media the user prefers: movie or tv...

--- a/src/nefarious/notification.py
+++ b/src/nefarious/notification.py
@@ -4,7 +4,7 @@ from nefarious.models import NefariousSettings
 
 
 def send_message(message: str) -> bool:
-    # apprise notifications - https://github.com/caronc/apprise
+    # apprise notifications - https://github.com/caronc/apprise/tree/v0.9.3
     nefarious_settings = NefariousSettings.get()
     if nefarious_settings.apprise_notification_url:
         apprise_instance = apprise.Apprise()


### PR DESCRIPTION
Fixes #285 

This simply updates all Apprise links to the version nefarious is using (0.9.3).