### PR TITLE
feat: Support scoping jackett searches with filter

### DIFF
--- a/src/frontend/src/app/settings/settings.component.ts
+++ b/src/frontend/src/app/settings/settings.component.ts
@@ -40,6 +40,7 @@ export class SettingsComponent implements OnInit, AfterContentChecked {
       'jackett_host': [settings['jackett_host'], Validators.required],
       'jackett_port': [settings['jackett_port'], Validators.required],
       'jackett_token': [settings['jackett_token'], Validators.required],
+      'jackett_filter_index': [settings['jackett_filter_index'], Validators.required],
       'transmission_host': [settings['transmission_host'], Validators.required],
       'transmission_port': [settings['transmission_port'], Validators.required],
       'transmission_user': [settings['transmission_user']],

--- a/src/nefarious/jackett.py
+++ b/src/nefarious/jackett.py
@@ -2,5 +2,8 @@ from nefarious.models import NefariousSettings
 
 
 def get_jackett_search_url(nefarious_settings: NefariousSettings):
-    return 'http://{}:{}/api/v2.0/indexers/all/results'.format(
-        nefarious_settings.jackett_host, nefarious_settings.jackett_port)
+    return "http://{}:{}/api/v2.0/indexers/{}/results".format(
+        nefarious_settings.jackett_host,
+        nefarious_settings.jackett_port,
+        nefarious_settings.jackett_filter_index,
+    )

--- a/src/nefarious/migrations/0001_initial.py
+++ b/src/nefarious/migrations/0001_initial.py
@@ -23,6 +23,7 @@ class Migration(migrations.Migration):
                 ('jackett_host', models.CharField(default='localhost', max_length=500)),
                 ('jackett_port', models.IntegerField(default=9117)),
                 ('jackett_token', models.CharField(max_length=500)),
+                ('jackett_filter_index', models.CharField(default='all', max_length=500)),
                 ('transmission_host', models.CharField(max_length=500)),
                 ('transmission_port', models.IntegerField(default=9091)),
                 ('transmission_user', models.CharField(max_length=500)),

--- a/src/nefarious/models.py
+++ b/src/nefarious/models.py
@@ -26,6 +26,7 @@ class NefariousSettings(models.Model):
     jackett_host = models.CharField(max_length=500, default='jackett')
     jackett_port = models.IntegerField(default=9117)
     jackett_token = models.CharField(max_length=500, default=JACKETT_TOKEN_DEFAULT)
+    jackett_filter_index = models.CharField(max_length=500, default="all", help_text='Optional Jackett index filter to use for searches')
 
     # transmission
     transmission_host = models.CharField(max_length=500, default='transmission')

--- a/src/nefarious/utils.py
+++ b/src/nefarious/utils.py
@@ -66,13 +66,20 @@ def verify_settings_transmission(nefarious_settings: NefariousSettings):
 
 def verify_settings_jackett(nefarious_settings: NefariousSettings):
     """
-    A special "all" indexer is available at /api/v2.0/indexers/all/results/torznab/api. It will query all configured indexers and return the combined results.
+    A special "all" indexer or filter-index is available at /api/v2.0/indexers/all/results/torznab/api. It will query all configured indexers and return the combined results.
     NOTE: /api/v2.0/indexers/all/results  will return json results vs torznab's xml response
     """
     try:
-        # make an unspecified query to the "all" indexer results endpoint and see if it's successful
-        response = requests.get('http://{}:{}/api/v2.0/indexers/all/results'.format(
-            nefarious_settings.jackett_host, nefarious_settings.jackett_port), params={'apikey': nefarious_settings.jackett_token}, timeout=60)
+        # make an unspecified query to the indexer results endpoint and see if it's successful
+        response = requests.get(
+            "http://{}:{}/api/v2.0/indexers/{}/results".format(
+                nefarious_settings.jackett_host,
+                nefarious_settings.jackett_port,
+                nefarious_settings.jackett_filter_index,
+            ),
+            params={"apikey": nefarious_settings.jackett_token},
+            timeout=60,
+        )
         response.raise_for_status()
         return response.json()
     except Exception as e:


### PR DESCRIPTION
* Created new setting for jackett that allows specifying a [filter-index](https://github.com/Jackett/Jackett?tab=readme-ov-file#filter-indexers) when not set will default to `all` leaving current behavior in place.
* Updated initial migrations to include new `nefarious_settings.jackett_filter_index`
* Updated `verify_settings_jackett` to include the set `nefarious_settings.jackett_filter_index` during verification
* Updated `get_jackett_search_url` to return with the current `nefarious_settings.jackett_filter_index` used.

Issue: [Fixes Issue #292](https://github.com/lardbit/nefarious/issues/292)