### PR TITLE
Only single "import library" task to run at a time

### DIFF
--- a/src/nefarious/tasks.py
+++ b/src/nefarious/tasks.py
@@ -431,7 +431,7 @@ def auto_watch_new_seasons_task():
             watch_show.save()
 
 
-@app.task(base=QueueOnce)
+@app.task(base=QueueOnce, once={'keys': []})  # queue once regardless of args
 def import_library_task(media_type: str, user_id: int, sub_path: str = None):
     user = get_object_or_404(User, pk=user_id)
     nefarious_settings = NefariousSettings.get()


### PR DESCRIPTION
Only allow a single "import library" task to run since we're using sqite and it can't handle concurrency (tables get locked)