### PR TITLE
Start celery-scheduler without a pid file

### DIFF
--- a/entrypoint-celery.sh
+++ b/entrypoint-celery.sh
@@ -17,5 +17,5 @@ if [ ! -z $CELERY_BEAT_SEPARATELY ]; then
 # run celery worker & scheduler at the same time
 # NOTE: this isn't advised since the scheduler could be potentially running multiple/simultaneous times creating duplicate tasks
 else
-  su $(id -un ${RUN_AS_UID}) -c "/env/bin/celery -A nefarious worker --concurrency ${NUM_CELERY_WORKERS:-0} --beat --loglevel=INFO"
+  su $(id -un ${RUN_AS_UID}) -c "/env/bin/celery -A nefarious worker --concurrency ${NUM_CELERY_WORKERS:-0} --beat --pidfile= --loglevel=INFO"
 fi


### PR DESCRIPTION
This fixes #324 by starting celery without defining a PID file which was preventing a new celery container to start due to a zombie process blocking the other.