### PR TITLE
Add named persistent docker volume for transmission's config directory

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -103,6 +103,7 @@ services:
       - PGID=${HOST_DOWNLOAD_GID:-1000}
     volumes:
       - ${HOST_DOWNLOAD_PATH:-/tmp}:/downloads
+      - transmission-db:/config
       - ./transmission-settings.json:/config/settings.json:ro
 
   # auto update service (to be extended)
@@ -122,3 +123,4 @@ services:
 volumes:
   nefarious-db:
   jackett-config:
+  transmission-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,3 +69,4 @@ services:
 volumes:
   nefarious-db:
   jackett-config:
+  transmission-db:


### PR DESCRIPTION
Fixes #330 by adding a named persistent docker volume for transmission's config.