### PR TITLE
Option to search excluding categories

### DIFF
--- a/src/frontend/src/app/api.service.ts
+++ b/src/frontend/src/app/api.service.ts
@@ -388,8 +388,8 @@ export class ApiService {
     );
   }
 
-  public searchTorrents(query: string, mediaType: string): Observable<any> {
-    return this.http.get(`${this.API_URL_SEARCH_TORRENTS}?q=${query}&media_type=${mediaType}`, {headers: this._requestHeaders()}).pipe(
+  public searchTorrents(query: string, mediaType: string, useCategories: boolean): Observable<any> {
+    return this.http.get(`${this.API_URL_SEARCH_TORRENTS}?q=${query}&media_type=${mediaType}&use_categories=${useCategories}`, {headers: this._requestHeaders()}).pipe(
       map((data: any) => {
         return data;
       }),

--- a/src/frontend/src/app/search/search-manual.component.html
+++ b/src/frontend/src/app/search/search-manual.component.html
@@ -10,6 +10,7 @@
           <span class="oi oi-magnifying-glass"></span> Search
         </button>
       </div>
+      <span><input [(ngModel)]="useCategories" name="useCategories" required type="checkbox" value="use_categories" checked="true" />Search by category</span>
     </form>
   </div>
 

--- a/src/frontend/src/app/search/search-manual.component.ts
+++ b/src/frontend/src/app/search/search-manual.component.ts
@@ -16,6 +16,7 @@ export class SearchManualComponent implements OnInit {
   @Input('mediaType') mediaType: string;
   @Output() downloaded = new EventEmitter<any>();
   public searchInput: string;
+  public useCategories: boolean = true;
   public orderByOptions = ['Name', 'Seeders', 'Size'];
   public results: any[] = [];
   public isSearching = false;
@@ -43,7 +44,7 @@ export class SearchManualComponent implements OnInit {
   public search() {
     this.results = [];
     this.isSearching = true;
-    this.apiService.searchTorrents(this.searchInput, this.mediaType).subscribe(
+    this.apiService.searchTorrents(this.searchInput, this.mediaType, this.useCategories ?? false).subscribe(
       (results) => {
         this.results = results;
         this.filterChange();

--- a/src/nefarious/api/views.py
+++ b/src/nefarious/api/views.py
@@ -185,7 +185,8 @@ class SearchTorrentsView(views.APIView):
     def get(self, request):
         query = request.query_params.get('q')
         media_type = request.query_params.get('media_type', SEARCH_MEDIA_TYPE_MOVIE)
-        search = SearchTorrents(media_type, query)
+        use_category = request.query_params.get('use_categories', True)
+        search = SearchTorrents(media_type, query, use_category)
         if not search.ok:
             return Response({'error': search.error_content}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(search.results)

--- a/src/nefarious/search.py
+++ b/src/nefarious/search.py
@@ -14,15 +14,17 @@ class SearchTorrents:
     error_content = None
     nefarious_settings: NefariousSettings
 
-    def __init__(self, media_type: str, query: str):
+    def __init__(self, media_type: str, query: str, include_category = True):
         assert media_type in [SEARCH_MEDIA_TYPE_TV, SEARCH_MEDIA_TYPE_MOVIE]
         self.nefarious_settings = NefariousSettings.get()
 
         params = {
             'apikey': self.nefarious_settings.jackett_token,
             'Query': query,
-            'Category[]': self._categories(media_type),
         }
+
+        if include_category:
+            params['Category[]'] = self._categories(media_type),
 
         res = requests.get(get_jackett_search_url(self.nefarious_settings), params, timeout=90)
         logger_background.info(f'jackett search: query={query}, url={res.url}')


### PR DESCRIPTION
Marking this a draft, as this solution feels a little clunky and would like to hear some feedback.

Normally, when nefarious performs a search, a category is included to limit the returned results to TV or MOVIE.
This PR adds a checkbox to the manual search which allows that category to be excluded.

The reason for this is that I was searching for some media, and neither automatic nor manual search could find the media, but performing a manual search in Jackett did, which was very confusing. On investigation, the particular media I was searching for had been miscategorized as a MOVIE on the trackers I had configured (can share details if necessary).

While I could obviously work around this by copying the manual Jackett results into Transmission, it's much nicer to remain in Nefarious as much as possible, especially for the save-location/renaming, and other less technically-inclined users of my deployment do _not_ want to mess around with multiple different services like that. :)