### PR TITLE
feat: Use mise to manage dev tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+mise.local.toml
+mise.*.local.toml
 env/
 venv/
 ENV/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    # NOTE: using "ports" when developing so local dev server can access redis
+    ports:
+      - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@
 # Create an .env file instead.
 # See https://github.com/lardbit/nefarious#part-1
 #####################################################
-version: '2.4'
-
 services:
 
   # nefarious main application
@@ -39,9 +37,6 @@ services:
     image: redis
     restart: always
     mem_limit: 200m
-    # NOTE: use "ports" when developing so local dev server can access redis
-    #ports:
-    #  - "6379:6379"
     expose:
       - 6379
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,41 +4,74 @@ If you're interested in developing, contributing or simply want to run nefarious
 
 nefarious is built on:
 
-- Python 3.8
+- Python 3.9
 - Django 3
-- Angular 10
-- Bootstrap 4
+- Angular 17
+- Bootstrap 5
 
 *Note*: Review the [Dockerfile](../Dockerfile) for all the necessary development dependencies.
 
+#### Install development tools
+
+The project uses [mise](https://mise.jdx.dev/) to install and select the local development tools. The committed `mise.toml` pins Python and Node to the versions used by the Dockerfiles, and installs `uv` for Python environment/dependency work.
+
+    mise trust
+    mise install
+
+Run commands through `mise run <task>` or activate mise in your shell before using `python`, `uv`, `npm`, or `docker-compose` directly.
+
 #### Install python dependencies
 
-This assumes you're either installing these packages in your global python environment (in which case you probably need to use `sudo`) or, even better, install a [virtual environment](https://docs.python.org/3/library/venv.html) first.
+mise creates and activates a local `.venv` using `uv`.
   
-    pip install -r src/requirements.txt
+    mise run install-python
+
+To install both backend and frontend dependencies:
+
+    mise run install
+
+#### Start development dependencies
+
+Jackett, Redis and Transmission are expected to be running somewhere.
+
+You can download and run them manually, or, for simplicity, run them via Docker Compose. The mise tasks include `docker-compose.dev.yml`, which publishes Redis on `localhost:6379` for local Django and Celery processes.
+
+To start Redis only:
+
+    mise run redis
+
+Before starting the full dependency stack, create a local `.env` file and adjust it for your development machine:
+
+    cp env.template .env
+
+At minimum, review `HOST_DOWNLOAD_PATH`, `HOST_DOWNLOAD_UID`, and `HOST_DOWNLOAD_GID`. If you are developing with VPN-backed Transmission, also fill in the `OPENVPN_*`, `LOCAL_NETWORK`, and `VPN_IPV6_DISABLED` settings as applicable.
+
+Then run Redis, Jackett and Transmission:
+
+    mise run deps
 
 #### Build database
   
-    python src/manage.py migrate
+    mise run migrate
 
 #### Run nefarious init script
 
 This creates a default user and pass (admin/admin).
 
-    python src/manage.py nefarious-init admin admin@localhost admin
+    mise run init
 
 
 #### Build front-end resources
 
 First install the frontend dependencies:
 
-    npm --prefix src/frontend install
+    mise run install-frontend
 
 Then build the frontend html/css stuff (angular):
     
-    npm --prefix src/frontend run build
+    mise run frontend-build
    
-Note: run `npm --prefix src/frontend run watch` to automatically rebuild while you're developing the frontend stuff.
+Note: run `mise run frontend-watch` to automatically rebuild while you're developing the frontend stuff.
    
 #### Run nefarious
 
@@ -46,7 +79,7 @@ Note: run `npm --prefix src/frontend run watch` to automatically rebuild while y
 
 This method is the default Django development server but *doesn't support websockets*.
 
-    DEBUG=1 python src/manage.py runserver 8000
+    mise run runserver
    
 It'll be now running at [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
@@ -56,11 +89,11 @@ This method runs the production server (with hot reload) and supports websockets
 
 Collect all the static assets:
 
-    python src/manage.py collectstatic --noinput
+    mise run collectstatic
     
 Run the server:
 
-    uvicorn nefarious.asgi:application --reload
+    mise run asgi
     
 It'll be now running at [http://127.0.0.1:8000](http://127.0.0.1:8000)
    
@@ -70,8 +103,7 @@ It'll be now running at [http://127.0.0.1:8000](http://127.0.0.1:8000)
 
 Run the celery server:
 
-    cd src
-    DEBUG=1 celery -A nefarious worker --loglevel=INFO
+    mise run celery
     
 You'll see all download logs/activity come out of here.
 
@@ -79,19 +111,8 @@ You'll see all download logs/activity come out of here.
 
 **NOTE**: By prefixing `DEBUG=1` before the celery command, all torrents will start as **paused** to avoid downloading anything.
 
-#### Dependencies
+#### Stop development services
 
-Jackett, Redis and Transmission are expected to be running somewhere.  
+Stop Docker Compose services and any local dev processes started by the mise tasks:
 
-You can download and run them manually, or, for simplicity, just run them via docker using the `docker-compose.yml` file.
-
-*NOTE* first update redis in the compose file to open its ports publicly during development:
-
-    ports:
-      - "6379:6379"
-    #expose:
-    #  - 6379
-
-Then run redis, jackett and transmission from the `docker-compose.yml` file:
-
-    docker-compose up -d redis jackett transmission
+    mise run dev-down

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,14 +11,52 @@ nefarious is built on:
 
 *Note*: Review the [Dockerfile](../Dockerfile) for all the necessary development dependencies.
 
-#### Install development tools
+#### Install and configure mise
 
 The project uses [mise](https://mise.jdx.dev/) to install and select the local development tools. The committed `mise.toml` pins Python and Node to the versions used by the Dockerfiles, and installs `uv` for Python environment/dependency work.
+
+Install mise with one of the supported methods from the [mise installation guide](https://mise.jdx.dev/installing-mise.html):
+
+    # macOS with Homebrew
+    brew install mise
+
+    # Linux/macOS installer script
+    curl https://mise.run | sh
+
+    # Windows with winget
+    winget install jdx.mise
+
+Configure mise in your shell so project tool versions and environment settings are activated when you enter the repository:
+
+    # bash
+    echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+
+    # zsh
+    echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+
+    # fish
+    echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+
+Restart your shell, then verify mise is active:
+
+    mise doctor
+
+Trust this repository's `mise.toml` and install the managed development tools:
 
     mise trust
     mise install
 
-Run commands through `mise run <task>` or activate mise in your shell before using `python`, `uv`, `npm`, or `docker-compose` directly.
+Docker is an OS-level prerequisite and is not managed by mise for this project. Install Docker Desktop on macOS or Windows, or Docker Engine on Linux, and make sure the Docker Compose plugin is available through Docker's supported platform installers:
+
+- [Install Docker Desktop](https://docs.docker.com/desktop/)
+- [Install Docker Engine](https://docs.docker.com/engine/install/)
+- [Install Docker Compose](https://docs.docker.com/compose/install/)
+
+After installation, verify that the plugin-style Compose command is available:
+
+    docker compose version
+
+Run commands through `mise run <task>` or activate mise in your shell before using `python`, `uv`, or `npm` directly.
 
 #### Install python dependencies
 
@@ -34,7 +72,7 @@ To install both backend and frontend dependencies:
 
 Jackett, Redis and Transmission are expected to be running somewhere.
 
-You can download and run them manually, or, for simplicity, run them via Docker Compose. The mise tasks include `docker-compose.dev.yml`, which publishes Redis on `localhost:6379` for local Django and Celery processes.
+You can download and run them manually, or, for simplicity, run them via Docker Compose. The mise tasks shell out to the OS-provided `docker compose` command and include `docker-compose.dev.yml`, which publishes Redis on `localhost:6379` for local Django and Celery processes.
 
 To start Redis only:
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,6 @@
 python = "3.9.21"
 node = "18.13.0"
 uv = "latest"
-docker-compose = "latest"
 
 [env]
 UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
@@ -67,16 +66,16 @@ run = "npm --prefix src/frontend run lint"
 
 [tasks.redis]
 description = "Start Redis via Docker Compose with localhost access for local Django/Celery"
-run = "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis"
+run = "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis"
 
 [tasks.deps]
 description = "Start Redis, Jackett, and Transmission via Docker Compose"
-run = "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis jackett transmission"
+run = "docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis jackett transmission"
 
 [tasks.dev-down]
 description = "Stop local development services started by mise tasks"
 run = """
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans
+docker compose -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans
 pkill -f "[u]vicorn nefarious.asgi:application --reload" || true
 pkill -f "[c]elery -A nefarious worker --loglevel=INFO" || true
 pkill -f "[p]ython manage.py runserver 8000" || true

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,84 @@
+[tools]
+python = "3.9.21"
+node = "18.13.0"
+uv = "latest"
+docker-compose = "latest"
+
+[env]
+UV_PYTHON = { value = "{{ tools.python.path }}", tools = true }
+_.python.venv = { path = ".venv", create = true, uv_create_args = ["--seed"] }
+
+[tasks.install-python]
+description = "Install backend Python dependencies into the mise-managed virtualenv"
+run = "uv venv --allow-existing --python \"$UV_PYTHON\" --seed .venv && uv pip install --python .venv -r src/requirements.txt"
+
+[tasks.install-frontend]
+description = "Install frontend npm dependencies"
+run = "npm --prefix src/frontend install"
+
+[tasks.install]
+description = "Install backend and frontend dependencies"
+depends = ["install-python", "install-frontend"]
+
+[tasks.migrate]
+description = "Apply Django database migrations"
+run = "cd src && python manage.py migrate"
+
+[tasks.init]
+description = "Create the default admin/admin development user"
+run = "cd src && python manage.py nefarious-init admin admin@localhost admin"
+
+[tasks.test]
+description = "Run the Django test suite"
+run = "cd src && python manage.py test"
+
+[tasks.runserver]
+description = "Run the Django development server without websocket support"
+run = "cd src && DEBUG=1 python manage.py runserver 8000"
+
+[tasks.collectstatic]
+description = "Collect Django static assets"
+run = "cd src && python manage.py collectstatic --noinput"
+
+[tasks.asgi]
+description = "Run the ASGI development server with websocket support"
+run = "cd src && uvicorn nefarious.asgi:application --reload"
+
+[tasks.celery]
+description = "Run the Celery worker with downloads paused in DEBUG mode"
+depends = ["redis"]
+run = "cd src && DEBUG=1 celery -A nefarious worker --loglevel=INFO"
+
+[tasks.frontend-build]
+description = "Build frontend static assets"
+run = "npm --prefix src/frontend run build"
+
+[tasks.frontend-watch]
+description = "Watch and rebuild frontend static assets"
+run = "npm --prefix src/frontend run watch"
+
+[tasks.frontend-test]
+description = "Run frontend tests"
+run = "npm --prefix src/frontend run test"
+
+[tasks.frontend-lint]
+description = "Run frontend lint"
+run = "npm --prefix src/frontend run lint"
+
+[tasks.redis]
+description = "Start Redis via Docker Compose with localhost access for local Django/Celery"
+run = "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis"
+
+[tasks.deps]
+description = "Start Redis, Jackett, and Transmission via Docker Compose"
+run = "docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d redis jackett transmission"
+
+[tasks.dev-down]
+description = "Stop local development services started by mise tasks"
+run = """
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml down --remove-orphans
+pkill -f "[u]vicorn nefarious.asgi:application --reload" || true
+pkill -f "[c]elery -A nefarious worker --loglevel=INFO" || true
+pkill -f "[p]ython manage.py runserver 8000" || true
+pkill -f "[n]g build --watch --output-path ../staticassets" || true
+"""

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -19,6 +19,6 @@ celery-once==3.0.1
 Unidecode==1.1.2
 psycopg2-binary==2.9.3
 apprise==0.9.3
-cryptography<3.4  # before rust requirement
+cryptography>=42,<43
 numpy==1.22.2
 opencv-contrib-python-headless==4.5.5.62

--- a/ty.toml
+++ b/ty.toml
@@ -1,0 +1,4 @@
+[environment]
+root = ["./src"]
+python = ".venv"
+python-version = "3.9"


### PR DESCRIPTION
[feat: Use mise to manage dev tools](https://github.com/lardbit/nefarious/pull/397/commits/5eea5eb7c372107068c1e1769b7e665f9cf74332)

* Updated DEVELOPMENT.md to reflect actual tool versions that were specified in Dockerfile and packages.json
* Added mise.toml and included the pinned tool versions setting uv and docker-compose to latest.
* Using uv to manage python version and virtual environment to ease and simplify setup.
* Created tasks in mise.toml to execute previously outlined steps in the DEVELOPMENT.md.
* Updated DEVELOPMENT.md to use mise task commands to execute development tasks. Also reorganized the DEVELOPMENT.md file so that the tasks can be executed in the order they are presented. Previously the dependencies were mentioned at the end which would cause celery to fail since the redis service wasn't running.
* Created a docker-compose.dev.yml that will expose the ports avoiding the need to uncomment this in the main docker-compose.yml file and added it as an override file in the mise task commands to ease development workflow.
* Updated cryptography in requirements.txt to higher version so that it will avoid trying to build on latest macos installations and just installs the wheel.
* Added a ty.toml in case its being used by the developer. This is a common formatter/linter used in the Zed editor. The ty.toml allows the nefarious imports to properly be handled when opening the project in the editor at the project root.

[fix: Use OS docker / Add mise install instructions](https://github.com/lardbit/nefarious/pull/397/commits/e544d853606c272af8e4616eec4e600a81222081)

* Updated documentation to call out that `docker` and `docker compose` are not managed by mise and are an os level install requirement for development.
* Added links to installation documentation for `docker` and `docker compose`
* Updated wording to specify that the mise tasks are shelling out to the OS-provided docker installation.
* Added installation and configuration instructions for the mise utility itself so it is clear during development setup.

Fixes Github Issue: #395 